### PR TITLE
Only one type should come after field_name

### DIFF
--- a/Interface-Definition.md
+++ b/Interface-Definition.md
@@ -198,7 +198,7 @@ venum
     = '(' ( field_name ** ',' ) _* ')'
 
 argument
-    = _* field_name _* ':' _* ( type ++ ',' )
+    = _* field_name _* ':' _* type
 
 vstruct
     = '(' ( argument ** ',' ) _* ')'


### PR DESCRIPTION
I'm not sure I am correct or not.
However, as far as comparing with "Grammer",  you may not want a type list after a field name.