### PR TITLE
Allow empty structs in interface definition

### DIFF
--- a/Interface-Definition.md
+++ b/Interface-Definition.md
@@ -111,6 +111,7 @@ element_type
 
 struct
         "(" struct_fields ")"
+        "(" ")"
 
 struct_fields
         struct_field


### PR DESCRIPTION
This is used by errors and methods.