### PR TITLE
Service: add two new generic errors

### DIFF
--- a/Service.md
+++ b/Service.md
@@ -34,6 +34,12 @@ error MethodNotImplemented (method: string)
 
 # One of the passed parameters is invalid.
 error InvalidParameter (parameter: string)
+
+# Client is denied access
+error PermissionDenied ()
+
+# Method is expected to be called with 'more' set to true, but wasn't
+error ExpectedMore ()
 ```
 
 ## Example Information


### PR DESCRIPTION
This adds two new errors to the generic service interface:

1. PermissionDenied(), carrying no parameters. In various services there are reason to deny access to specific clients. It would be good if we had a generic error we could return in this case. There are no parameters, since the precise reason might not be something the service might want to reveal to the client, because security sensitive.

   Expected use-case: for example any system service listening on AF_UNIX varlink services that checks SO_PEERCRED or similar for access controls.

2. ExpectedMore(), carrying no parameters. In various subscription calls it often makes sense to refuse clients that do not set the "more" flag. Let's add a generic error that services can report to clients about this case.

   Expected use-case: any service that provides subscription functionality that only makes sense to be called with "more" set to true.

Fixes: #22