### PR TITLE
Language-Bindings.md: Add varlink-js

### DIFF
--- a/Language-Bindings.md
+++ b/Language-Bindings.md
@@ -5,6 +5,7 @@ title: "Language Bindings"
 ## Existing language bindings
 * [C](https://github.com/varlink/libvarlink)
 * [Go](https://github.com/varlink/go)
+* [JavaScript](https://github.com/pzmarzly/varlink-js)
 * [Python](https://github.com/varlink/python)
 * [Rust](https://github.com/varlink/rust)
 
@@ -29,6 +30,7 @@ b
 | -----------|:------|:------|:------|
 | C          | TUABb |       |       |
 | Go         | TUABb | TUABb | Tb    |
+| JavaScript | TU    | TU    | T     |
 | Python     | TUABb | TUABb | Tb    |
 | Rust       | TUABb | TUABb | TUBb  |
 

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -24,6 +24,8 @@ docs:
         url: https://github.com/varlink/go
       - title: "Java"
         url: https://github.com/varlink/java
+      - title: "JavaScript"
+        url: https://github.com/pzmarzly/varlink-js
       - title: "Python"
         url: https://github.com/varlink/python
       - title: "Rust"


### PR DESCRIPTION
I recently wrote a Varlink client and server library in TypeScript (JavaScript), for my own fun. It's far from perfect, but can pass the certification tests (both in server role and client role, see README), so I guess it belongs here now?

https://github.com/pzmarzly/varlink-js
