### PR TITLE
use permalinks to code snippet lines

### DIFF
--- a/Home.md
+++ b/Home.md
@@ -149,7 +149,7 @@ A listen socket a.k.a "FD3" might be passed to a varlink service at startup.
 
 The service activator should pass the command line option _--varlink=[ADDRESS](#address)_ to the service, to make the listening address and possible parameters known to the service. It also shows the listening address in _ps_, which helps to debug a running service.
 
-See an example implementation of a [service activator](https://github.com/cherry-pick/com.redhat.resolver/blob/master/src/service.c#L112).
+See an example implementation of a [service activator](https://github.com/cherry-pick/com.redhat.resolver/blob/71114fbd57660c510503bb98460e7aa53627d78f/src/service.c#L114).
 
 ## Resolver
 Public varlink interfaces are registered system-wide by their well-known address, by default _/run/org.varlink.resolver_. The resolver translates a given varlink interface to the service address which provides this interface.

--- a/Language-Bindings.md
+++ b/Language-Bindings.md
@@ -47,7 +47,8 @@ Start(), Test01(), Test02(…), …, Testxx(…), End()
 ```
 
 The return value of the previous call should be the argument of the next call.
-See the example clients in [python](https://github.com/varlink/python/blob/master/varlink/tests/test_certification.py) or [rust](https://github.com/varlink/rust/blob/master/varlink-certification/src/main.rs#L73-L138).
+See the example clients in [python](https://github.com/varlink/python/blob/master/varlink/tests/test_certification.py)
+or [rust](https://github.com/varlink/rust/blob/ed3417ccbfc85ec30676bc0fe41290c94059b21a/varlink-certification/src/main.rs#L98-L161).
 
 Then you test your client against the python varlink certification server:
 


### PR DESCRIPTION
otherwise the context can be wrong; the rust one already points to different lines than originally intended

---

it could also be fine to merely remove the L line markers from the url so it doesn't matter as much. or make every github url a permalink instead of a master branch reference. or to just not change anything, since maybe i'm picky that i clicked a url and got random lines highlighted :)