### PR TITLE
Mark reply parameters as optional

### DIFF
--- a/Method-Call.md
+++ b/Method-Call.md
@@ -26,7 +26,7 @@ Call and Reply are objects with properties, they are conceptually similar to HTT
 ## Reply
 ```nim
 (
-  parameters: object,
+  parameters: ?object,
   continues: ?bool,
   error: ?string
 )


### PR DESCRIPTION
In practice, it seems a few implementations send null instead of an empty object when a reply has no parameters. Mark the parameters field as optional.

(The call parameters were already optional.)